### PR TITLE
Add workflow for converting submodules to subtrees

### DIFF
--- a/.github/workflows/convert_submodules_to_subtrees.yml
+++ b/.github/workflows/convert_submodules_to_subtrees.yml
@@ -1,0 +1,68 @@
+---
+# This GitHub Action converts all Git submodules into subtrees.
+#
+# Motivation
+# ==========
+# Managing dependencies as submodules requires additional commands to update
+# each module and may break CI/CD processes if someone forgets to initialize or
+# update them. Subtrees flatten these dependencies into the repository while
+# preserving a connection back to the source repository. By running the
+# conversion in CI we ensure that every branch can easily transition from
+# submodules to subtrees with minimal manual work.
+#
+# Usage
+# -----
+# This workflow is triggered manually through the "workflow_dispatch" event. It
+# checks out the repository, executes the conversion script and commits the
+# resulting changes to a new branch named `subtree-conversion-<run-id>`.
+# Review the branch and merge it using a pull request once satisfied.
+#
+# The workflow does not run automatically on push to avoid modifying history
+# without review. It is intended as a one-time migration tool.
+#
+# Steps Overview
+# 1. Checkout the full Git history so `git subtree` works correctly.
+# 2. Run the provided script that replaces each submodule with a subtree.
+# 3. Create a new branch for the conversion result and commit the changes.
+# 4. Push the branch back to the repository for review.
+#
+# If the conversion produces no changes (for example, there were no submodules),
+# the workflow will exit without creating a new branch.
+# ------------------------------------------------------------------------------
+
+name: Convert Submodules to Subtrees
+"on":
+  workflow_dispatch:
+    inputs:
+      base-branch:
+        description: 'Branch to start the conversion from'
+        required: false
+        default: "main"
+
+jobs:
+  convert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.base-branch }}
+
+      - name: Run conversion script
+        run: bash scripts/convert_submodules_to_subtrees.sh
+
+      - name: Commit and push changes
+        run: |
+          set -e
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          branch="subtree-conversion-${{ github.run_id }}"
+          git checkout -b "$branch"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes detected. Nothing to commit."
+            exit 0
+          fi
+          git commit -m "Convert submodules to subtrees"
+          git push origin HEAD:"$branch"

--- a/README.md
+++ b/README.md
@@ -11,4 +11,15 @@ To start working on a Chewy Stack version, run:
 chewy-cc git checkout 0.1.0
 ```
 
-This will make sure all related packages are checked out to the same version. Essentially, we want to make sure that if someone is working on Chewy v0.1.1, for example, each component is in sync.
+This ensures all related packages are checked out to the same version.
+
+## Converting Submodules to Subtrees
+
+Submodules can be replaced with Git subtrees for simpler dependency management. Run the helper script from the repository root:
+You can also trigger the **Convert Submodules to Subtrees** GitHub Action to generate a branch automatically.
+
+```bash
+./scripts/convert_submodules_to_subtrees.sh
+```
+
+See [SUBTREE_CONVERSION.md](SUBTREE_CONVERSION.md) for more information.

--- a/SUBTREE_CONVERSION.md
+++ b/SUBTREE_CONVERSION.md
@@ -1,0 +1,36 @@
+# Converting Submodules to Subtrees
+
+This repository historically tracked many dependencies via Git submodules. While submodules can be useful, they add management overhead and often require additional commands (`git submodule update`) to keep each dependency in sync. Git subtrees offer a simpler alternative by embedding the external repository directly into the main tree.
+
+The `scripts/convert_submodules_to_subtrees.sh` script automates the conversion from submodules to subtrees. It reads the `.gitmodules` file, removes each submodule, and then adds the corresponding repository as a subtree.
+
+## Usage
+
+1. **Create a backup branch** (recommended):
+   ```bash
+   git checkout -b backup-before-subtree
+   ```
+
+2. **Run the conversion script** from the root of the repository:
+   ```bash
+   ./scripts/convert_submodules_to_subtrees.sh
+   ```
+
+3. **Review the changes** and commit them:
+   ```bash
+   git status
+   git add -A
+   git commit -m "Convert submodules to subtrees"
+   ```
+
+The script assumes that each submodule uses the `main` branch unless a different branch is specified in `.gitmodules` via the `submodule.<name>.branch` setting.
+
+After converting, submodule configuration files (`.gitmodules` and references within `.git/config`) will be removed. Each dependency will exist as a normal directory in the repository, managed with `git subtree`.
+
+## Using the GitHub Action
+
+A preconfigured GitHub Action can perform the conversion automatically. Trigger the
+workflow named **"Convert Submodules to Subtrees"** from the Actions tab. The
+workflow creates a new branch containing the converted subtrees which you can
+review and merge via a pull request.
+

--- a/scripts/convert_submodules_to_subtrees.sh
+++ b/scripts/convert_submodules_to_subtrees.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# ---------------------------------------------------------------------------
+# convert_submodules_to_subtrees.sh
+# ---------------------------------------------------------------------------
+# This script converts all Git submodules in the current repository into
+# Git subtrees. The goal is to simplify the repository structure by
+# embedding external dependencies directly into the main tree instead of
+# referencing them as submodules.
+#
+# Submodules are referenced by entries in the `.gitmodules` file. When this
+# script runs, it performs the following high-level steps for each
+# submodule:
+#   1. Extract the submodule path and repository URL from `.gitmodules`.
+#   2. Remove the submodule using `git submodule deinit` and `git rm`.
+#   3. Delete the submodule's entry from `.gitmodules`.
+#   4. Add the remote repository as a subtree using `git subtree add`.
+#
+# Each subtree is added with the `--squash` flag to keep the history concise.
+# The script also attempts to detect the branch associated with the submodule
+# definition. If no branch is specified, it defaults to `main`.
+#
+# Usage:
+#   ./scripts/convert_submodules_to_subtrees.sh
+#
+# The script must be run from the root of the repository. Because it performs
+# destructive operations (removing submodules), it is recommended to create a
+# backup branch before running:
+#   git checkout -b backup-before-subtree
+#
+# After conversion, review the changes and commit them as appropriate.
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+# Ensure we are at the root of the repository by checking for .git
+if [[ ! -d .git ]]; then
+  echo "Error: this script must be run from the root of a Git repository" >&2
+  exit 1
+fi
+
+# Abort if there are no submodules
+if [[ ! -f .gitmodules ]]; then
+  echo "No .gitmodules file found. Nothing to convert." >&2
+  exit 0
+fi
+
+# Read all submodule paths from .gitmodules
+mapfile -t SUBMODULE_PATHS < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}')
+
+if [[ ${#SUBMODULE_PATHS[@]} -eq 0 ]]; then
+  echo "No submodules defined in .gitmodules." >&2
+  exit 0
+fi
+
+for PATH in "${SUBMODULE_PATHS[@]}"; do
+  NAME=$(basename "$PATH")
+  URL=$(git config -f .gitmodules --get submodule."$NAME".url)
+  BRANCH=$(git config -f .gitmodules --get submodule."$NAME".branch 2>/dev/null || echo "main")
+
+  echo "Converting submodule $NAME (path: $PATH, url: $URL, branch: $BRANCH)"
+
+  # Deinitialize and remove the submodule
+  git submodule deinit -f "$PATH" || true
+  git rm -f "$PATH"
+  rm -rf ".git/modules/$PATH" || true
+
+  # Remove the submodule entry from .gitmodules
+  git config -f .gitmodules --remove-section "submodule.$NAME" || true
+
+  # If .gitmodules is empty after removal, delete it
+  if [[ -z $(git config -f .gitmodules --list) ]]; then
+    rm -f .gitmodules
+  fi
+
+  # Add the repository as a subtree
+  git subtree add --prefix="$PATH" "$URL" "$BRANCH" --squash
+
+done
+
+echo "Submodule conversion complete. Review the changes and commit them as needed." 


### PR DESCRIPTION
## Summary
- add `convert_submodules_to_subtrees.yml` GitHub Action with extensive documentation
- mention the workflow in README
- document the action in `SUBTREE_CONVERSION.md`

## Testing
- `shellcheck scripts/convert_submodules_to_subtrees.sh`
- `bash -n scripts/convert_submodules_to_subtrees.sh`
- `yamllint .github/workflows/convert_submodules_to_subtrees.yml`


------
https://chatgpt.com/codex/tasks/task_e_68625762d014832cbd6ac1ce25e4e4f3